### PR TITLE
feat: use var.name to avoid naming conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ module "ssm-bastion" {
 | encrypted | n/a | `bool` | `true` | no |
 | environment | The environment name | `string` | n/a | yes |
 | instance\_type | n/a | `string` | n/a | yes |
-| name | Name of the ec2 instance | `string` | n/a | yes |
+| name | Name of the bastion host | `string` | n/a | yes |
 | ssm\_standard\_role | n/a | `string` | n/a | yes |
 | subnet\_id | n/a | `string` | n/a | yes |
 | vpc\_id | n/a | `string` | n/a | yes |

--- a/aws_iam_role.ssm_role.tf
+++ b/aws_iam_role.ssm_role.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "ssm_role" {
-  name               = "ssm-terraform"
+  name               = "${var.name}-ssm-terraform"
   assume_role_policy = data.aws_iam_policy_document.assume.json
 }
 

--- a/aws_key_pair.ssm_key.tf
+++ b/aws_key_pair.ssm_key.tf
@@ -1,5 +1,5 @@
 resource "aws_key_pair" "ssm_key" {
-  key_name   = "ssm-key"
+  key_name   = "${var.name}-ssm-key"
   public_key = tls_private_key.ssh.public_key_openssh
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -35,7 +35,7 @@ variable "environment" {
 
 variable "name" {
   type        = string
-  description = "Name of the ec2 instance"
+  description = "Name of the bastion host"
 }
 
 variable "encrypted" {


### PR DESCRIPTION
Avoid naming conflicts by using var.name as prefix for aws_iam_role and aws_key_pair. This makes it possible to install multiple bastion hosts on the same AWS account.